### PR TITLE
Use libreoffice still

### DIFF
--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -7,16 +7,10 @@ USER root
 COPY --chown=imio *.cfg *.conf requirements.txt Makefile /plone/
 # Required by docsplit: default-jre-headless libreoffice-java-common libreoffice-writer libreoffice-calc
 
-RUN add-apt-repository -yu ppa:libreoffice/libreoffice-still
 RUN apt-get update -qqy \
   && apt-get full-upgrade -qqy \
   && apt-get install -qqy --no-install-recommends \
      lynx \
-     default-jre-headless \
-     libreoffice-java-common \
-     libreoffice-writer \
-     libreoffice-calc \
-     libreoffice-script-provider-python \
      file \
      imagemagick \
      graphicsmagick \
@@ -80,6 +74,8 @@ RUN apt-get update -qqy \
 FROM harbor.imio.be/common/plone-base:4.3.20-ubuntu
 ENV DELIB_MAJOR=4.2
 
+ARG LO_VERSION=25.2
+
 LABEL delib=$DELIB_VERSION \
       name="ia.Delib" \
       description="ia.Delib image, based on harbor.imio.be/common/plone-base:4.3.20-ubuntu-20.04" \
@@ -93,36 +89,45 @@ COPY --chown=imio docker/docker-initialize.py docker/*.sh /plone/
 WORKDIR /plone
 USER root
 # Required by docsplit: default-jre-headless libreoffice-java-common libreoffice-writer libreoffice-calc
-
-RUN add-apt-repository -yu ppa:libreoffice/libreoffice-still
-RUN apt-get update \
-  && apt-get full-upgrade -qqy \
-  && apt-get install -qqy --no-install-recommends \
-     lynx \
-     default-jre-headless \
-     libreoffice-java-common \
-     libreoffice-writer \
-     libreoffice-calc \
-     libreoffice-script-provider-python \
-     file \
-     imagemagick \
-     graphicsmagick \
-     ghostscript \
-     poppler-data \
-     ruby \
-     libmagic1 \
-     libldap-2.5-0 \
-     ldap-utils \
-     libldap-common \
-     libpq5 \
-     lbzip2 \
-     libsigc++-2.0-0v5 \
-     zint \
-  && rm -rf /var/lib/apt/lists/* \
-  && gem install docsplit \
-  && echo "TLS_REQCERT	allow" >> /etc/ldap/ldap.conf \
-  && su -c "bin/pip install 'python-ldap==2.4.15' -r requirements.txt" -s /bin/bash imio \
-  && chmod +x /plone/*.sh
+RUN set -eux; \
+    add-apt-repository -y ppa:libreoffice/libreoffice-still; \
+    apt-get update -qqy; \
+    apt-get full-upgrade -qqy; \
+    apt-get install -qqy --no-install-recommends \
+      lynx \
+      default-jre-headless \
+      libreoffice-java-common \
+      libreoffice-writer \
+      libreoffice-calc \
+      libreoffice-script-provider-python \
+      file \
+      imagemagick \
+      graphicsmagick \
+      ghostscript \
+      poppler-data \
+      ruby \
+      libmagic1 \
+      libldap-2.5-0 \
+      ldap-utils \
+      libldap-common \
+      libpq5 \
+      lbzip2 \
+      libsigc++-2.0-0v5 \
+      zint; \
+    \
+    if ! libreoffice --version | grep -q "^LibreOffice ${LO_VERSION}\."; then \
+      echo >&2 "ERROR: Expected LibreOffice ${LO_VERSION}.x but got:"; \
+      libreoffice --version >&2 || true; \
+      echo >&2 "APT candidate versions for libreoffice-common:"; \
+      apt-cache policy libreoffice-common >&2 || true; \
+      exit 1; \
+    fi; \
+    \
+    gem install docsplit; \
+    echo "TLS_REQCERT	allow" >> /etc/ldap/ldap.conf; \
+    su -c "bin/pip install 'python-ldap==2.4.15' -r requirements.txt" -s /bin/bash imio; \
+    chmod +x /plone/*.sh; \
+    rm -rf /var/lib/apt/lists/*
 
 USER imio
 

--- a/docker/Dockerfile-base
+++ b/docker/Dockerfile-base
@@ -7,7 +7,7 @@ USER root
 COPY --chown=imio *.cfg *.conf requirements.txt Makefile /plone/
 # Required by docsplit: default-jre-headless libreoffice-java-common libreoffice-writer libreoffice-calc
 
-# RUN add-apt-repository -yu ppa:libreoffice/libreoffice-still \
+RUN add-apt-repository -yu ppa:libreoffice/libreoffice-still
 RUN apt-get update -qqy \
   && apt-get full-upgrade -qqy \
   && apt-get install -qqy --no-install-recommends \
@@ -94,7 +94,7 @@ WORKDIR /plone
 USER root
 # Required by docsplit: default-jre-headless libreoffice-java-common libreoffice-writer libreoffice-calc
 
-# RUN add-apt-repository -yu ppa:libreoffice/libreoffice-still \
+RUN add-apt-repository -yu ppa:libreoffice/libreoffice-still
 RUN apt-get update \
   && apt-get full-upgrade -qqy \
   && apt-get install -qqy --no-install-recommends \

--- a/docker/Dockerfile-latest
+++ b/docker/Dockerfile-latest
@@ -7,6 +7,7 @@ USER root
 # Required by docsplit: default-jre-headless libreoffice-java-common libreoffice-writer libreoffice-calc
 
 COPY --chown=imio *.cfg *.conf requirements.txt Makefile docker/docker-initialize.py docker/*.sh /plone/
+RUN add-apt-repository -yu ppa:libreoffice/libreoffice-still
 RUN apt-get update \
   && apt-get full-upgrade -qqy \
   && apt-get install -qqy --no-install-recommends \

--- a/docker/Dockerfile-latest
+++ b/docker/Dockerfile-latest
@@ -7,16 +7,10 @@ USER root
 # Required by docsplit: default-jre-headless libreoffice-java-common libreoffice-writer libreoffice-calc
 
 COPY --chown=imio *.cfg *.conf requirements.txt Makefile docker/docker-initialize.py docker/*.sh /plone/
-RUN add-apt-repository -yu ppa:libreoffice/libreoffice-still
 RUN apt-get update \
   && apt-get full-upgrade -qqy \
   && apt-get install -qqy --no-install-recommends \
      lynx \
-     default-jre-headless \
-     libreoffice-java-common \
-     libreoffice-writer \
-     libreoffice-calc \
-     libreoffice-script-provider-python \
      file \
      imagemagick \
      graphicsmagick \
@@ -82,6 +76,8 @@ RUN apt-get update \
 FROM harbor.imio.be/delib/iadelib:base
 ENV DELIB_MAJOR=4.2
 
+ARG LO_VERSION=25.2
+
 LABEL delib=$DELIB_VERSION \
       name="ia.Delib" \
       description="ia.Delib image, based on harbor.imio.be/common/plone-base:4.3.20-ubuntu-20.04" \
@@ -92,9 +88,29 @@ COPY --from=builder /usr/local/lib/python2.7/dist-packages /usr/local/lib/python
 COPY --chown=imio --from=builder /plone /plone/
 COPY --chown=imio scripts/*.py /plone/scripts
 
+USER root
+RUN set -eux; \
+    add-apt-repository -y ppa:libreoffice/libreoffice-still; \
+    apt-get update -qqy; \
+    apt-get install -qqy --no-install-recommends \
+      default-jre-headless \
+      libreoffice-java-common \
+      libreoffice-writer \
+      libreoffice-calc \
+      libreoffice-script-provider-python; \
+    \
+    if ! libreoffice --version | grep -q "^LibreOffice ${LO_VERSION}\."; then \
+      echo >&2 "ERROR: Expected LibreOffice ${LO_VERSION}.x but got:"; \
+      libreoffice --version >&2 || true; \
+      echo >&2 "APT candidate versions for libreoffice-common:"; \
+      apt-cache policy libreoffice-common >&2 || true; \
+      exit 1; \
+    fi; \
+    \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /plone
 USER imio
-
 ENV ZEO_ADDRESS=zeo:8100 \
  OO_SERVER=libreoffice \
  OO_PORT=2002 \

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   libreoffice:
-    image: harbor.imio.be/common/libreoffice:7.3
+    image: harbor.imio.be/common/libreoffice:25.2
     command: soffice --headless --norestore --accept="socket,host=libreoffice,port=2002,tcpNoDelay=1;urp;StarOffice.ServiceManager"
     expose:
       - "2002"

--- a/docker/docker-compose-minimal.yml
+++ b/docker/docker-compose-minimal.yml
@@ -2,7 +2,7 @@ version: '2.4'
 services:
 
   libreoffice:
-    image: harbor.imio.be/common/libreoffice:7.3
+    image: harbor.imio.be/common/libreoffice:25.2
     command: soffice --headless --norestore --accept="socket,host=libreoffice,port=2002,tcpNoDelay=1;urp;StarOffice.ServiceManager"
     expose:
       - "2002"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.4'
 services:
 
   libreoffice:
-    image: harbor.imio.be/common/libreoffice:7.3
+    image: harbor.imio.be/common/libreoffice:25.2
     command: soffice --headless --norestore --accept="socket,host=libreoffice,port=2002,tcpNoDelay=1;urp;StarOffice.ServiceManager"
     expose:
       - "2002"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded LibreOffice container image from 7.3 to 25.2 across deployment configs.
  * Enabled LibreOffice Still PPA in the build and expanded LibreOffice + utility packages installed.
  * Added a build-time LibreOffice version check (build fails if installed version mismatches expected).
  * Added maintainer metadata and integrated ruby/python/docsplit installation and cleanup into the build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->